### PR TITLE
Added support to Context2D 'transform' method

### DIFF
--- a/TeaLeaf/jni/js/js_context.cpp
+++ b/TeaLeaf/jni/js/js_context.cpp
@@ -132,6 +132,22 @@ Handle<Value> defScale(const Arguments& args) {
 
 }
 
+Handle<Value> defTransform(const Arguments& args) {
+	LOGFN("transform");
+	HandleScope handleScope;
+	double a = args[0]->NumberValue();
+	double b = args[1]->NumberValue();
+	double c = args[2]->NumberValue();
+	double d = args[3]->NumberValue();
+	double e = args[4]->NumberValue();
+	double f = args[5]->NumberValue();
+
+	context_2d_transform(GET_CONTEXT2D(), a, b, c, d, e, f);
+
+	LOGFN("endtransform");
+	return Undefined();
+}
+
 Handle<Value> defSave(const Arguments& args) {
 	LOGFN("save");
 	HandleScope handleScope;
@@ -808,6 +824,7 @@ Handle<ObjectTemplate> get_context_2d_class_template() {
 	context_2d_class_template->Set(STRING_CACHE_rotate, FunctionTemplate::New(defRotate));
 	context_2d_class_template->Set(STRING_CACHE_scale, FunctionTemplate::New(defScale));
 	context_2d_class_template->Set(STRING_CACHE_translate, FunctionTemplate::New(defTranslate));
+	context_2d_class_template->Set(STRING_CACHE_transform, FunctionTemplate::New(defTransform));
 	context_2d_class_template->Set(STRING_CACHE_save, FunctionTemplate::New(defSave));
 	context_2d_class_template->Set(STRING_CACHE_restore, FunctionTemplate::New(defRestore));
 	context_2d_class_template->Set(STRING_CACHE_clear, FunctionTemplate::New(defClear));

--- a/TeaLeaf/jni/js/js_string_cache.cpp
+++ b/TeaLeaf/jni/js/js_string_cache.cpp
@@ -184,6 +184,7 @@ Persistent<String> STRING_CACHE_tick;
 Persistent<String> STRING_CACHE_versionCode;
 Persistent<String> STRING_CACHE_baseline;
 Persistent<String> STRING_CACHE_translate;
+Persistent<String> STRING_CACHE_transform;
 Persistent<String> STRING_CACHE_getHeight;
 Persistent<String> STRING_CACHE_setOpacity;
 Persistent<String> STRING_CACHE_strokeText;
@@ -405,6 +406,7 @@ void js_string_cache_init() {
 	STRING_CACHE_versionCode = Persistent<String>::New(String::New("versionCode"));
 	STRING_CACHE_baseline = Persistent<String>::New(String::New("baseline"));
 	STRING_CACHE_translate = Persistent<String>::New(String::New("translate"));
+	STRING_CACHE_transform = Persistent<String>::New(String::New("transform"));
 	STRING_CACHE_getHeight = Persistent<String>::New(String::New("getHeight"));
 	STRING_CACHE_setOpacity = Persistent<String>::New(String::New("setOpacity"));
 	STRING_CACHE_strokeText = Persistent<String>::New(String::New("strokeText"));

--- a/TeaLeaf/jni/js/js_string_cache.h
+++ b/TeaLeaf/jni/js/js_string_cache.h
@@ -187,6 +187,7 @@ extern Persistent<String> STRING_CACHE_tick;
 extern Persistent<String> STRING_CACHE_versionCode;
 extern Persistent<String> STRING_CACHE_baseline;
 extern Persistent<String> STRING_CACHE_translate;
+extern Persistent<String> STRING_CACHE_transform;
 extern Persistent<String> STRING_CACHE_getHeight;
 extern Persistent<String> STRING_CACHE_setOpacity;
 extern Persistent<String> STRING_CACHE_strokeText;


### PR DESCRIPTION
I need to use the context `transform` method in one of my projects.
I noticed that such function was not provided by Game Closure, but since the other transformations (`transform`, `scale`, `rotate`) were already present, this one was trivial to implement.
The patch to `native-core` (to add `context_2d_transform`) is ready as well, here is the one for `native-android` that adds the function to the context through JNI.
