### PR TITLE
Fix for multiple addons including the same JAR file

### DIFF
--- a/build.js
+++ b/build.js
@@ -401,8 +401,12 @@ var installAddonCode = function(builder, opts, next) {
 			for (var ii = 0; ii < jars.length; ++ii) {
 				var jarPath = jars[ii];
 				var jarDestPath = path.join(destDir, "libs", path.basename(jarPath));
-				logger.log("Installing JAR file:", jarDestPath);
-				fs.symlinkSync(jarPath, jarDestPath, 'junction');
+				if (!fs.existsSync(jarDestPath)) {
+					logger.log("Installing JAR file:", jarDestPath);
+					fs.symlinkSync(jarPath, jarDestPath, 'junction');
+				} else {
+					logger.warn("JAR file:", jarDestPath, 'already installed by other addon.');
+				}
 			}
 		} else {
 			logger.log("No JAR file data to install");


### PR DESCRIPTION
When multiple addons include the same JAR file (e.g.
“google-play-services.jar”) the build process currently breaks. This
fix checks if the JAR is already present in the destination path and if
so, logs a warning instead of breaking the build.
