### PR TITLE
fix (package.json): add sh to preinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "wrench": "~1.3.9"
   },
   "scripts": {
-    "preinstall": "./preinstall.sh",
+    "preinstall": "sh ./preinstall.sh",
     "postinstall": "make setup && make clean || true"
   },
   "private": true,


### PR DESCRIPTION
Explicitly call preinstall.sh with the sh command
to help installations work on windows.
