### PR TITLE
texture manager fixes

### DIFF
--- a/TeaLeaf/jni/platform/native.cpp
+++ b/TeaLeaf/jni/platform/native.cpp
@@ -16,7 +16,7 @@
  */
 #include "platform/native.h"
 #include "platform/platform.h"
-
+#include "core/texture_manager.h"
 
 const char* get_market_url() {
     native_shim* shim = get_native_shim();
@@ -124,6 +124,7 @@ void set_halfsized_textures(bool on) {
     native_shim *shim = get_native_shim();
     jmethodID method = shim->env->GetMethodID(shim->type, "setHalfsizedTexturesSetting", "(Z)V");
     shim->env->CallVoidMethod(shim->instance, method, (jboolean)on);
+    texture_manager_set_use_halfsized_textures(on);
 }
 
 void native_stay_awake(bool on) {

--- a/TeaLeaf/jni/platform/native_shim.cpp
+++ b/TeaLeaf/jni/platform/native_shim.cpp
@@ -177,7 +177,7 @@ extern "C" {
     }
 
     void Java_com_tealeaf_NativeShim_setHalfsizedTextures(JNIEnv *env, jobject thiz, jboolean on) {
-        use_halfsized_textures = on;
+        texture_manager_set_use_halfsized_textures(on);
     }
 
     JNIEXPORT jboolean JNICALL Java_com_tealeaf_NativeShim_initJS(JNIEnv* env, jobject thiz, jstring uri, jstring android_hash) {

--- a/TeaLeaf/jni/platform/resource_loader.cpp
+++ b/TeaLeaf/jni/platform/resource_loader.cpp
@@ -123,20 +123,14 @@ CEXPORT void launch_remote_texture_load(const char *url) {
 }
 
 CEXPORT bool resource_loader_load_image_with_c(texture_2d * texture) {
-    texture->pixel_data=NULL;
+    texture->pixel_data = NULL;
 
-    bool skip = false;
     // check if it is a special url (text, contacts, etc.), if it is then load in java
-    if (texture->url[0] == '@') {
-        skip = true;
-    }
-
-    if(!skip) {
+    bool skip = texture->url[0] == '@' || texture->is_canvas || texture->is_text;
+    if (!skip) {
         unsigned long sz;
         unsigned char *data = resource_loader_read_file(texture->url, &sz);
-
         texture->pixel_data = texture_2d_load_texture_raw(texture->url, data, sz, &texture->num_channels, &texture->width, &texture->height, &texture->originalWidth, &texture->originalHeight, &texture->scale, &texture->used_texture_bytes, &texture->compression_type);
-
         free(data);
     }
 
@@ -146,8 +140,7 @@ CEXPORT bool resource_loader_load_image_with_c(texture_2d * texture) {
         return true;
     } else {
         launch_remote_texture_load(texture->url);
-
-        // using java
+        // load using java
         return false;
     }
 }

--- a/TeaLeaf/jni/platform/text_manager.cpp
+++ b/TeaLeaf/jni/platform/text_manager.cpp
@@ -57,6 +57,7 @@ texture_2d *text_manager_get_text(const char *font_name, int size, const char *t
         tex->originalHeight /= scale;
         tex->width /= scale;
         tex->height /= scale;
+        tex->is_text = true;
     }
     return tex;
 }

--- a/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
@@ -716,7 +716,7 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 				Settings settings = view.context.getSettings();
 				boolean useHalfsizedTextures = settings.getBoolean(
 						"@__use_halfsized_textures__", false);
-				NativeShim.setHalfsizedTextures(false);
+				NativeShim.setHalfsizedTextures(useHalfsizedTextures);
 
 				initJS = false;
 			}
@@ -741,16 +741,12 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 						new LocationManager(view.context),
 						resourceManager, view.context);
 
-				// 100 MB of texture memory
 				int device_limit = Device.getDeviceMemory();
-				if (device_limit == -1) {
-					logger.log("Falling back to default device memory limit");
-					device_limit = 200000000; // assume 200MB
+				if (device_limit != -1) {
+					NativeShim.textureManagerSetMaxMemory(device_limit / 2);
 				}
 				logger.log("Device Memory Limit", device_limit);
-				NativeShim.textureManagerSetMaxMemory(device_limit / 2);
 			}
-
 
 			if (shouldReloadTextures) {
 				NativeShim.initGL(0);
@@ -762,7 +758,6 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 			}
 
 			EventQueue.pushEvent(new RedrawOffscreenBuffersEvent());
-
 		}
 
 		public Bitmap getScreenshot(GL10 gl) {


### PR DESCRIPTION
* fixed halfsized textures forced to false
* call halfsized textures setter rather than update global
* dont make assumptions about memory limits, rely on texture manager defaults
* updated native-core submodule