### PR TITLE
temp - prevent defunct track.gameclosure.com calls

### DIFF
--- a/TeaLeaf/src/com/tealeaf/RemoteLogger.java
+++ b/TeaLeaf/src/com/tealeaf/RemoteLogger.java
@@ -281,6 +281,6 @@ public class RemoteLogger implements ILogger {
 	}
 
 	private void send(String event) throws Exception {
-		http.post(url, event);
+		// http.post(url, event);
 	}
 }


### PR DESCRIPTION
these go to an endpoint that is no longer listening and seem to surface an
issue when spammed across other requests where the cookies are sometimes
incorrectly set against the gameclosure.com domain instead of the correct
domain