### PR TITLE
refactor remove ff

### DIFF
--- a/AndroidManifest.xsl
+++ b/AndroidManifest.xsl
@@ -6,6 +6,9 @@
 	<xsl:param name="version" />
 	<xsl:param name="versionCode" />
 
+	<xsl:param name="minSdkVersion">8</xsl:param>
+	<xsl:param name="targetSdkVersion">14</xsl:param>
+
 	<xsl:param name="gameHash">0.0</xsl:param>
 	<xsl:param name="sdkHash">1.0</xsl:param>
 	<xsl:param name="androidHash">1.0</xsl:param>
@@ -35,6 +38,14 @@
 		<xsl:copy>
 			<xsl:apply-templates select="@*|node()" />
 		</xsl:copy>
+	</xsl:template>
+
+	<xsl:template match="uses-sdk/@android:minSdkVersion">
+		<xsl:attribute name="android:minSdkVersion"><xsl:value-of select="$minSdkVersion" /></xsl:attribute>
+	</xsl:template>
+
+	<xsl:template match="uses-sdk/@android:targetSdkVersion">
+		<xsl:attribute name="android:targetSdkVersion"><xsl:value-of select="$targetSdkVersion" /></xsl:attribute>
 	</xsl:template>
 
 	<xsl:template match="application/@android:debuggable">

--- a/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
@@ -635,6 +635,8 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 			Point size = new Point();
 			TeaLeaf tealeaf = this.view.context;
 			WindowManager w = tealeaf.getWindowManager();
+			int orientation = tealeaf.getRequestedOrientation();
+			boolean isPortrait = orientation == ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
 
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR2) {
 				w.getDefaultDisplay().getSize(size);
@@ -646,34 +648,39 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 				sh = d.getHeight();
 			}
 
-			// Calculate longer screen side
-			int longerScreenSide = sw;
-			if (longerScreenSide < sh) {
-				longerScreenSide = sh;
-			}
-
 			boolean success = false;
-
-			if (longerScreenSide > 1024) {
-				success = trySplashImage("splash-2048.png");
+			int[] sizes;
+			int screenSide;
+			String prefix = "splash-portrait";
+			if (isPortrait) {
+				sizes = new int[] {2048, 1136, 1024, 960, 480, 0};
+				screenSide = sw < sh ? sh : sw;
+			} else {
+				sizes = new int[] {1536, 768, 0};
+				prefix = "splash-landscape";
+				screenSide = sw < sh ? sw : sh;
 			}
-			
-			if (!success && longerScreenSide > 512) {
-				success = trySplashImage("splash-1024.png");
-			} 
-			
+
+			int n = sizes.length - 1;
+			for (int i = 0; i < n; ++i) {
+				if (screenSide > sizes[i + 1]) {
+					if (success = trySplashImage(prefix + sizes[i] + ".png")) {
+						break;
+					}
+				}
+			}
+
 			if (!success) {
-				success = trySplashImage("splash-512.png");
-
-				// Use much larger splashes if smaller ones cannot be found:
-
-				if (!success && longerScreenSide <= 512) {
-					success = trySplashImage("splash-1024.png");
+				// use larger splashes if smaller ones cannot be found
+				for (int i = n; i > 0; i--) {
+					if (success = trySplashImage(prefix + sizes[i] + ".png")) {
+						break;
+					}
 				}
+			}
 
-				if (!success && longerScreenSide <= 1024) {
-					success = trySplashImage("splash-2048.png");
-				}
+			if (!success) {
+				success = trySplashImage("splash-universal.png");
 			}
 
 			if (!success) {
@@ -682,7 +689,7 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 
 			logger.log("{core} Device screen (", sw, ",", sh, "), using splash '", tealeaf.getOptions().getSplash(), "'");
 		}
-		
+
 		public void onSurfaceChanged(GL10 gl, int width, int height) {
 
 			if (this.view.context.getRequestedOrientation() == ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE

--- a/build.js
+++ b/build.js
@@ -831,7 +831,11 @@ exports.build = function(api, app, config, cb) {
 
   var apkBuildName = "";
   if (!config.debug) {
-    apkBuildName = shortName + "-aligned.apk";
+    if (skipSigning) {
+      apkBuildName = shortName + "-release-unsigned.apk";
+    } else {
+      apkBuildName = shortName + "-aligned.apk";
+    }
   } else {
     apkBuildName = shortName + "-debug.apk";
   }

--- a/build.js
+++ b/build.js
@@ -751,6 +751,8 @@ function updateManifest(api, app, config, opts) {
     gameHash: app.manifest.version,
     sdkHash: config.sdkVersion,
     androidHash: androidVersion,
+    minSdkVersion: config.argv['min-sdk-version'] || 8,
+    targetSdkVersion: config.argv['target-sdk-version'] || 14,
     debuggable: config.debug ? 'true' : 'false'
   });
 

--- a/build.js
+++ b/build.js
@@ -13,67 +13,85 @@
  * along with the Game Closure SDK.  If not, see <http://mozilla.org/MPL/2.0/>.
  */
 
-var path = require("path");
-var fs = require("fs");
-var ff = require("ff");
-var clc = require("cli-color");
-var wrench = require('wrench');
 var util = require('util');
-var crypto = require('crypto');
+var path = require('path');
 var spawn = require('child_process').spawn;
-var mkdirp = require('mkdirp');
+var Promise = require('bluebird');
+var fs = Promise.promisifyAll(require('fs-extra'));
+var chalk = require('chalk');
 
+// unexpected exceptions show stack, build errors should just show the error
+// message to the user
+var BuildError = function (message, showStack) {
+  this.message = chalk.red(message);
+  this.showStack = showStack || false;
+};
+
+util.inherits(BuildError, Error);
+
+exports.BuildError = BuildError;
+
+var existsAsync = function (filename) {
+  return new Promise(function (resolve) {
+    if (!filename) { return resolve(false); }
+
+    fs.exists(filename, function (exists) {
+      resolve(exists);
+    });
+  });
+};
+
+// used to remove punctuation (if any) from the appid
+var PUNCTUATION_REGEX = /[!"#$%&'()*+,\-.\/:;<=>?@\[\\\]^_`{|}~]/g;
+
+var ANDROID_TARGET = "android-19";
 var androidVersion = require('./package.json').version;
 
 var logger;
 
-
-function spawnWithLogger(api, name, args, opts, cb) {
-  var logger = api.logging.get(name);
-  logger.log(name, args.join(' '));
-  var child = spawn(name, args, opts);
-  child.stdout.pipe(logger, {end: false});
-  child.stderr.pipe(logger, {end: false});
-  child.on('close', function (err) {
-    cb(err);
+function spawnWithLogger(api, name, args, opts) {
+  return new Promise(function (resolve, reject) {
+    var logger = api.logging.get(name);
+    logger.log(name, args.join(' '));
+    var streams = logger.createStreams(['stdout'], {silent: false});
+    var child = spawn(name, args, opts);
+    child.stdout.pipe(streams.stdout);
+    child.stderr.pipe(streams.stdout);
+    child.on('exit', function (code) {
+      if (code) {
+        logger.log(streams.get('stdout'));
+        logger.warn(name, 'exited with non-zero exit code (' + code + ')');
+        reject(code);
+      } else {
+        console.log(name, 'ended normally');
+        resolve();
+      }
+    });
   });
 }
 
-function copyFileSync(from, to) {
-  fs.writeFileSync(to, fs.readFileSync(from));
-}
-
-
 //// Modules
 
-var getModuleConfig = function(api, app, config, cb) {
-  var config = {};
-  var f = ff(function () {
-    Object.keys(app.modules).forEach(function (moduleName) {
+var getModuleConfig = function(api, app) {
+  var moduleConfig = {};
+  return Promise.map(Object.keys(app.modules), function (moduleName) {
       var modulePath = app.modules[moduleName].path;
       var configFile = path.join(modulePath, 'android', 'config.json');
-      var next = f.wait();
-      fs.readFile(configFile, 'utf8', function(err, data) {
-        // modules are not required to have a config.json, so if loading config.json fails, consume the error
-        if (err && err.code == 'ENOENT') { return next(); }
-        if (err) { next(err); }
-
-        try {
-          config[moduleName] = {
+      return fs.readFileAsync(configFile, 'utf8')
+        .then(function (data) {
+          moduleConfig[moduleName] = {
             config: JSON.parse(data),
             path: modulePath
           };
-        } catch (e) {
-          return next(e);
-        }
-
-        next();
-      });
-    });
-
-    f(config);
-  }).cb(cb);
-}
+        }, function (err) {
+          // modules are not required to have a config.json, ignore missing file
+          if (err && err.code !== 'ENOENT') {
+            throw err;
+          }
+        });
+    })
+    .return(moduleConfig);
+};
 
 var getTextBetween = function(text, startToken, endToken) {
   var start = text.indexOf(startToken);
@@ -84,8 +102,7 @@ var getTextBetween = function(text, startToken, endToken) {
   var offset = text.substring(start).indexOf("\n") + 1;
   var afterStart = start + offset;
   return text.substring(afterStart, end);
-
-}
+};
 
 var replaceTextBetween = function(text, startToken, endToken, replaceText) {
   var newText = "";
@@ -100,375 +117,298 @@ var replaceTextBetween = function(text, startToken, endToken, replaceText) {
   newText += replaceText;
   newText += text.substring(end);
   return newText;
-}
+};
 
-function injectPluginXML(opts, cb) {
+function injectPluginXML(opts) {
   var moduleConfig = opts.moduleConfig;
   var outputPath = opts.outputPath;
-  var manifestXml = path.join(outputPath, "AndroidManifest.xml");
+  var manifestXml = path.join(outputPath, 'AndroidManifest.xml');
 
-  var f = ff(function() {
-    var group = f.group();
+  var readPluginXMLFiles = Object.keys(moduleConfig).map(function (moduleName) {
+    var injectionXML = moduleConfig[moduleName].config.injectionXML;
 
-    for (var moduleName in moduleConfig) {
-      var injectionXML = moduleConfig[moduleName].config.injectionXML;
+    if (injectionXML) {
+      var filepath = path.join(moduleConfig[moduleName].path, 'android', injectionXML);
+      logger.log('Reading plugin XML:', filepath);
 
-      if (injectionXML) {
-        var filepath = path.join(moduleConfig[moduleName].path, 'android', injectionXML);
-        logger.log("Reading plugin XML:", filepath);
-
-        fs.readFile(filepath, "utf-8", group());
-      }
+      return fs.readFileAsync(filepath, 'utf-8');
     }
+  });
 
-    fs.readFile(manifestXml, "utf-8", f());
-  }, function(results, xml) {
-    // TODO: don't use regular expressions
+  return Promise.all([
+      fs.readFileAsync(manifestXml, 'utf-8')
+    ].concat(readPluginXMLFiles))
+    .then(function (results) {
+      var xml = results.shift();
 
-    if (results && results.length > 0 && xml && xml.length > 0) {
-      var XML_START_PLUGINS_MANIFEST = "<!--START_PLUGINS_MANIFEST-->";
-      var XML_END_PLUGINS_MANIFEST = "<!--END_PLUGINS_MANIFEST-->";
-      var XML_START_PLUGINS_ACTIVITY = "<!--START_PLUGINS_ACTIVITY-->";
-      var XML_END_PLUGINS_ACTIVITY = "<!--END_PLUGINS_ACTIVITY-->";
-      var XML_START_PLUGINS_APPLICATION = "<!--START_PLUGINS_APPLICATION-->";
-      var XML_END_PLUGINS_APPLICATION = "<!--END_PLUGINS_APPLICATION-->";
+      // TODO: don't use regular expressions
 
-      var manifestXmlManifestStr = "";
-      var manifestXmlActivityStr = "";
-      var manifestXmlApplicationStr = "";
+      if (results && results.length > 0 && xml && xml.length > 0) {
+        var XML_START_PLUGINS_MANIFEST = '<!--START_PLUGINS_MANIFEST-->';
+        var XML_END_PLUGINS_MANIFEST = '<!--END_PLUGINS_MANIFEST-->';
+        var XML_START_PLUGINS_ACTIVITY = '<!--START_PLUGINS_ACTIVITY-->';
+        var XML_END_PLUGINS_ACTIVITY = '<!--END_PLUGINS_ACTIVITY-->';
+        var XML_START_PLUGINS_APPLICATION = '<!--START_PLUGINS_APPLICATION-->';
+        var XML_END_PLUGINS_APPLICATION = '<!--END_PLUGINS_APPLICATION-->';
 
-      for (var i = 0; i < results.length; ++i) {
-        var pluginXml = results[i];
+        var manifestXmlManifestStr = '';
+        var manifestXmlActivityStr = '';
+        var manifestXmlApplicationStr = '';
 
-        manifestXmlManifestStr += getTextBetween(pluginXml, XML_START_PLUGINS_MANIFEST, XML_END_PLUGINS_MANIFEST);
-        manifestXmlActivityStr += getTextBetween(pluginXml, XML_START_PLUGINS_ACTIVITY, XML_END_PLUGINS_ACTIVITY);
-        manifestXmlApplicationStr += getTextBetween(pluginXml, XML_START_PLUGINS_APPLICATION, XML_END_PLUGINS_APPLICATION);
+        for (var i = 0; i < results.length; ++i) {
+          var pluginXml = results[i];
+          if (!pluginXml) { continue; }
+
+          manifestXmlManifestStr += getTextBetween(pluginXml, XML_START_PLUGINS_MANIFEST, XML_END_PLUGINS_MANIFEST);
+          manifestXmlActivityStr += getTextBetween(pluginXml, XML_START_PLUGINS_ACTIVITY, XML_END_PLUGINS_ACTIVITY);
+          manifestXmlApplicationStr += getTextBetween(pluginXml, XML_START_PLUGINS_APPLICATION, XML_END_PLUGINS_APPLICATION);
+        }
+
+        xml = replaceTextBetween(xml, XML_START_PLUGINS_MANIFEST, XML_END_PLUGINS_MANIFEST, manifestXmlManifestStr);
+        xml = replaceTextBetween(xml, XML_START_PLUGINS_ACTIVITY, XML_END_PLUGINS_ACTIVITY, manifestXmlActivityStr);
+        xml = replaceTextBetween(xml, XML_START_PLUGINS_APPLICATION, XML_END_PLUGINS_APPLICATION, manifestXmlApplicationStr);
+        return fs.writeFileAsync(manifestXml, xml, 'utf-8');
+      } else {
+        logger.log('No plugin XML to inject');
       }
-
-      xml = replaceTextBetween(xml, XML_START_PLUGINS_MANIFEST, XML_END_PLUGINS_MANIFEST, manifestXmlManifestStr);
-      xml = replaceTextBetween(xml, XML_START_PLUGINS_ACTIVITY, XML_END_PLUGINS_ACTIVITY, manifestXmlActivityStr);
-      xml = replaceTextBetween(xml, XML_START_PLUGINS_APPLICATION, XML_END_PLUGINS_APPLICATION, manifestXmlApplicationStr);
-      fs.writeFile(manifestXml, xml, "utf-8", f.wait());
-    } else {
-      logger.log("No plugin XML to inject");
-    }
-  }).cb(cb);
+    });
 }
 
-var installModuleCode = function (api, app, opts, cb) {
+var installModuleCode = function (api, app, opts) {
   var moduleConfig = opts.moduleConfig;
   var outputPath = opts.outputPath;
 
-  var filePaths = [];
-  var replacers = [];
-  var libraries = [];
-  var jars = [];
-  var jarPaths = [];
+  function handleFile(baseDir, filePath, replacer) {
+    var ext = path.extname(filePath);
+    if (ext == '.java' || ext === '.aidl') {
+      return fs.readFileAsync(path.join(baseDir, filePath), 'utf-8')
+        .then(function (contents) {
+          var pkgName = contents.match(/(package[\s]+)([a-z.A-Z0-9]+)/g)[0].split(' ')[1];
+          var pkgDir = pkgName.replace(/\./g, "/");
+          var outFile = path.join(outputPath, "src", pkgDir, path.basename(filePath));
 
-  var f = ff(function() {
-    var group = f.group();
+          logger.log("Installing Java package", pkgName, "to", outFile);
 
-    for (var moduleName in moduleConfig) {
-      var config = moduleConfig[moduleName].config;
-      var modulePath = moduleConfig[moduleName].path;
-
-      if (config.copyFiles) {
-        for (var ii = 0; ii < config.copyFiles.length; ++ii) {
-          var filePath = path.join(modulePath, 'android', config.copyFiles[ii]);
-
-          logger.log("Installing module Java code:", filePath);
-
-          replacers.push(config.injectionSource);
-
-          if (path.extname(filePath) === ".java" ||
-            path.extname(filePath) === ".aidl") {
-            filePaths.push(filePath);
-            fs.readFile(filePath, "utf-8", group.slot());
-          } else {
-            filePaths.push(config.copyFiles[ii]);
-            fs.readFile(filePath, "binary", group.slot());
-          }
-        }
-      }
-
-      if (config.copyGameFiles) {
-        for (var ii = 0; ii < config.copyGameFiles.length; ++ii) {
-          var filePath = path.join(app.paths.root, config.copyGameFiles[ii]);
-          replacers.push(config.injectionSource);
-
-          if (path.extname(filePath) === ".java" ||
-            path.extname(filePath) === ".aidl") {
-            filePaths.push(filePath);
-            fs.readFile(filePath, "utf-8", group.slot());
-          } else {
-            filePaths.push(config.copyGameFiles[ii]);
-            fs.readFile(filePath, "binary", group.slot());
-          }
-        }
-      }
-
-      if (config.libraries) {
-        for (var ii = 0; ii < config.libraries.length; ++ii) {
-          var library = path.join(modulePath, 'android', config.libraries[ii]);
-
-          logger.log("Installing module library:", library);
-
-          libraries.push(library);
-
-          // Set up library build files
-          spawnWithLogger(api, 'android', [
-              "update", "project", "--target", opts.target,
-              "--path", library
-              ], {}, f.wait());
-        }
-      }
-
-      if (config.jars) {
-        for (var ii = 0; ii < config.jars.length; ++ii) {
-          var jar = path.join(modulePath, 'android', config.jars[ii]);
-
-          logger.log("Installing module JAR:", jar);
-
-          jars.push(jar);
-        }
-      }
-    }
-
-    fs.readFile(path.join(outputPath, "project.properties"), "utf-8", f());
-
-  }, function(results, properties) {
-    if (results && results.length > 0) {
-      for (var ii = 0; ii < results.length; ++ii) {
-        var data = results[ii];
-        var filePath = filePaths[ii];
-
-        if (data) {
-          if (path.extname(filePath) === ".java" ||
-            path.extname(filePath) === ".aidl") {
-            var pkgName = data.match(/(package[\s]+)([a-z.A-Z0-9]+)/g)[0].split(' ')[1];
-            var pkgDir = pkgName.replace(/\./g, "/");
-            var outFile = path.join(outputPath, "src", pkgDir, path.basename(filePath));
-
-            logger.log("Installing Java package", pkgName, "to", outFile);
-
-            wrench.mkdirSyncRecursive(path.dirname(outFile));
-
-            // Run injectionSource section of associated module
-            var replacer = replacers[ii];
-            if (replacer && replacer.length > 0) {
-              for (var jj = 0; jj < replacer.length; ++jj) {
-                var findString = replacer[jj].regex;
-                var keyForReplace = replacer[jj].keyForReplace;
-                var replaceString = app.manifest.android[keyForReplace];
-                if (replaceString) {
-                  logger.log(" - Running find-replace for", findString, "->", replaceString, "(android:", keyForReplace + ")");
-                  var rexp = new RegExp(findString, "g");
-                  data = data.replace(rexp, replaceString);
-                } else {
-                  logger.error(" - Unable to find android key for", keyForReplace);
-                }
+          // Run injectionSource section of associated module
+          if (replacer && replacer.length > 0) {
+            for (var jj = 0; jj < replacer.length; ++jj) {
+              var findString = replacer[jj].regex;
+              var keyForReplace = replacer[jj].keyForReplace;
+              var replaceString = app.manifest.android[keyForReplace];
+              if (replaceString) {
+                logger.log(" - Running find-replace for", findString, "->", replaceString, "(android:", keyForReplace + ")");
+                var rexp = new RegExp(findString, "g");
+                contents = contents.replace(rexp, replaceString);
+              } else {
+                logger.error(" - Unable to find android key for", keyForReplace);
               }
             }
-
-            fs.writeFile(outFile, data, 'utf-8', f.wait());
-          } else if (path.extname(filePath) === ".so") {
-            var armeabi_out = ["libs/armeabi", "libs/armeabi-v7a"];
-            for(var jj = 0; jj != armeabi_out.length; jj++) {
-              var outFile = path.join(outputPath, armeabi_out[jj], path.basename(filePath));
-              logger.log("Writing shared object", filePath, "to", outFile);
-              wrench.mkdirSyncRecursive(path.dirname(outFile));
-              fs.writeFile(outFile, data, 'binary', f.wait());
-            }
-          } else {
-            var outFile = path.join(outputPath, filePath);
-            wrench.mkdirSyncRecursive(path.dirname(outFile));
-            fs.writeFile(outFile, data, 'binary', f.wait());
           }
-        } else {
-          logger.warn("Unable to read Java package", filePath);
-        }
-      }
+
+          return fs.outputFileAsync(outFile, contents, 'utf-8');
+        });
+    } else if (ext == '.so') {
+      var src = path.join(baseDir, filePath);
+      var basename = path.basename(filePath);
+      return Promise.all([
+        fs.copyAsync(src, path.join(outputPath, 'libs', 'armeabi', basename)),
+        fs.copyAsync(src, path.join(outputPath, 'libs', 'armeabi-v7a', basename))
+      ]);
     } else {
-      logger.log("No Java packages to add");
+      return fs.copyAsync(path.join(baseDir, filePath), path.join(outputPath, filePath));
     }
+  }
 
-    if (properties && properties.length > 0) {
-      //find largest uncommented library reference number
-      var i = 0;
-      var refStr = "android.library.reference.";
-      var refNum = 1;
-      for (;;) {
-        var offset = properties.substring(i).indexOf("android.library.reference.");
-        i = offset + i;
-        if (offset == -1) {
-          break;
-        }
-        if (properties[i - 1] == "#") {
-          i += refStr.length;
-          continue;
-        }
-        i += refStr.length;
-        refNum++;
-      }
+  function installLibraries(libraries) {
+    if (!libraries || !libraries.length) { return; }
 
-      var libStr = "";
-      for (var i = 0; i < libraries.length; i ++) {
-        var libProp = refStr + refNum + "=" + path.relative(outputPath, libraries[i]);
+    var projectPropertiesFile = path.join(outputPath, "project.properties");
 
-        logger.log("Installing library property:", libProp);
+    var libraryFiles = libraries.map(function (library) {
+      return path.join(modulePath, 'android', library);
+    });
 
-        libStr += libProp + "\n";
-        refNum++;
-      }
+    return Promise.map(libraryFiles, function (libraryFile) {
+        // Set up library build files
+        logger.log("Installing module library:", libraryFile);
+        return spawnWithLogger(api, 'android', [
+            "update", "project", "--target", ANDROID_TARGET,
+            "--path", libraryFile
+          ]);
+      })
+      .then(function () {
+        return fs.readFileAsync(projectPropertiesFile, "utf-8");
+      })
+      .then(function (properties) {
+        // find the largest library reference number
+        var libraryNumber = 1;
+        properties.replace(/^[^#]+android\.library\.reference\.(\d+).*$/gm, function (line, ref) {
+          // for each (uncommented) line with a library reference
+          ref = parseInt(ref);
+          if (ref >= libraryNumber) {
+            libraryNumber = ref + 1;
+          }
+        });
 
-      properties += libStr;
+        var libraryReferences = '\n' + libraryFiles.map(function (library) {
+            var key = 'android.library.reference.' + (libraryNumber++);
+            var value = path.relative(outputPath, library);
+            return key + '=' + value;
+          })
+          .join('\n');
 
-      fs.writeFile(path.join(outputPath, "project.properties"), properties, "utf-8", f.wait());
-    } else {
-      logger.log("No library properties to add");
-    }
+        return fs.appendFileAsync(projectPropertiesFile, libraryReferences);
+      });
+  }
 
-    if (jars && jars.length > 0) {
-      for (var ii = 0; ii < jars.length; ++ii) {
-        var jarPath = jars[ii];
-        var jarDestPath = path.join(outputPath, "libs", path.basename(jarPath));
-        logger.log("Installing JAR file:", jarDestPath);
-        try { fs.unlinkSync(jarDestPath); } catch (e) {}
-        fs.symlinkSync(jarPath, jarDestPath, 'junction');
-      }
-    } else {
-      logger.log("No JAR file data to install");
-    }
-  }).cb(cb);
-}
+  function installJar(jarFile) {
+    logger.log("Installing module JAR:", jarFile);
+    var jarDestPath = path.join(outputPath, "libs", path.basename(jarFile));
+
+    logger.log("Installing JAR file:", jarDestPath);
+    return fs.unlinkAsync(jarDestPath)
+      .catch(function () {})
+      .then(function () {
+        return fs.symlinkAsync(jarFile, jarDestPath, 'junction');
+      });
+  }
+
+  var tasks = [];
+  for (var moduleName in moduleConfig) {
+    var config = moduleConfig[moduleName].config;
+    var modulePath = moduleConfig[moduleName].path;
+
+    config.copyFiles && config.copyFiles.forEach(function (filename) {
+      tasks.push(handleFile(path.join(modulePath, 'android'), filename, config.injectionSource));
+    });
+
+    config.copyGameFiles && config.copyGameFiles.forEach(function (filename) {
+      tasks.push(handleFile(app.paths.root, filename, config.injectionSource));
+    });
+
+    config.jars && config.jars.forEach(function (jar) {
+      tasks.push(installJar(path.join(modulePath, 'android', jar)));
+    });
+
+    tasks.push(installLibraries(config.libraries));
+  }
+
+  return Promise.all(tasks);
+};
 
 
 //// Utilities
 
-function nextStep() {
-  var func = arguments[arguments.length - 1];
-  return func(null);
-}
-
-function transformXSL(api, inFile, outFile, xslFile, params, cb) {
-  var outFileTemp = outFile + ".temp";
-
-  var f = ff(function() {
-    for (var key in params) {
-      if (typeof params[key] != 'string') {
-        if (params[key] == undefined || typeof params[key] == 'object') {
-          logger.error("settings for AndroidManifest: value for", clc.yellowBright(key), "is not a string");
-        }
-
-        params[key] = JSON.stringify(params[key]);
+function transformXSL(api, inFile, outFile, xslFile, params) {
+  for (var key in params) {
+    if (typeof params[key] !== 'string') {
+      if (!params[key] || typeof params[key] === 'object') {
+        logger.error("settings for AndroidManifest: value for", chalk.yellow(key), "is not a string");
       }
+
+      params[key] = JSON.stringify(params[key]);
     }
+  }
 
-    api.jvmtools.exec({
-      tool: 'xslt',
-      args: [
-        "--in", inFile,
-        "--out", outFileTemp,
-        "--stylesheet", xslFile,
-        "--params", JSON.stringify(params)
-        ]
-      }, f());
-  }, function (xslt) {
-    var logger = api.logging.get('xslt');
-    xslt.on('out', logger.out);
-    xslt.on('err', logger.err);
-    xslt.on('end', f.wait());
-  }, function () {
-    fs.readFile(outFileTemp, 'utf-8', f());
-  }, function(dat) {
-    dat = dat.replace(/android:label=\"[^\"]*\"/g, "android:label=\""+params.title+"\"");
+  var outFileTemp = outFile + ".temp";
+  return new Promise(function (resolve, reject) {
+      api.jvmtools.exec({
+        tool: 'xslt',
+        args: [
+          "--in", inFile,
+          "--out", outFileTemp,
+          "--stylesheet", xslFile,
+          "--params", JSON.stringify(params)
+          ]
+        }, function (err, xslt) {
+          if (err) { return reject(err); }
 
-    fs.writeFile(outFile, dat, 'utf-8', f.wait());
-  }).cb(cb);
+          var logger = api.logging.get('xslt');
+          xslt.on('out', logger.out);
+          xslt.on('err', logger.err);
+          xslt.on('end', resolve);
+        });
+    })
+    .then(function () {
+      return fs.readFileAsync(outFileTemp, 'utf-8');
+    })
+    .then(function(contents) {
+      contents = contents.replace(/android:label=\"[^\"]*\"/g, "android:label=\""+params.title+"\"");
+      fs.writeFileAsync(outFile, contents, 'utf-8');
+    });
 }
 
-var PUNCTUATION_REGEX = /[!"#$%&'()*+,\-.\/:;<=>?@\[\\\]^_`{|}~]/g;
-var PUNCTUATION_OR_SPACE_REGEX = /[!"#$%&'()*+,\-.\/:;<=>?@\[\\\]^_`{|}~ ]/g;
+function buildSupportProjects(api, config) {
+  var rootDir = __dirname;
+  var tealeafDir = path.join(__dirname, 'TeaLeaf');
+  var singleArch = config.argv.arch;
+  return Promise.try(function () {
+      if (config.clean || singleArch) {
+        return spawnWithLogger(api, 'make', ['clean'], {cwd: rootDir});
+      }
+    })
+    .then(function () {
+      var args = ["-j", "8", (config.debug ? "DEBUG=1" : "RELEASE=1")];
+      if (singleArch) {
+        args.push('APP_ABI=' + singleArch);
+      }
 
-function buildSupportProjects(api, opts, cb) {
-  var f = ff(this, function() {
-    if (opts.clean || opts.arch) {
-      spawnWithLogger(api, 'make', ['clean'], {cwd: __dirname}, f.slot());
-    }
-  }, function() {
-    var args = ["-j", "8", (opts.debug ? "DEBUG=1" : "RELEASE=1")];
-    if (opts.arch) {
-      args.push('APP_ABI=' + opts.arch);
-    }
-    spawnWithLogger(api, 'ndk-build', args , { cwd: path.join(__dirname, "TeaLeaf") }, f.wait());
-  }).cb(cb);
+      return spawnWithLogger(api, 'ndk-build', args , {cwd: tealeafDir});
+    });
 }
 
-function saveLocalizedStringsXmls(outputPath, titles, cb) {
+function saveLocalizedStringsXmls(outputPath, titles) {
   var stringsXmlPath = path.join(outputPath, "res/values/strings.xml");
   var stringsXml = fs.readFileSync(stringsXmlPath, "utf-8");
-  var f = ff(function () {
-    Object.keys(titles).forEach(function (lang) {
+  return Promise.map(Object.keys(titles), function (lang) {
       var title = titles[lang];
       var i = stringsXml.indexOf('</resources>');
       var first = stringsXml.substring(0, i);
       var second = stringsXml.substring(i);
       var inner = '<string name="title">' + title + '</string>';
       var finalXml = first + inner + second;
-      //default en
-      var next = f();
-      if (lang === 'en') {
-        fs.writeFile(path.join(outputPath, "res/values/strings.xml"), finalXml, 'utf-8', next);
-      } else {
-        mkdirp(path.join(outputPath, "res/values-" + lang), function (err) {
-          if (err) { return next(err); }
-          fs.writeFile(path.join(outputPath, "res/values-" + lang + "/strings.xml"), finalXml, 'utf-8', next);
-        });
-      }
+      var values = lang == 'en' ? 'values' : 'values-' + lang;
+      var stringsFile = path.join(outputPath, 'res', values, 'strings.xml');
+      return fs.outputFileAsync(stringsFile, finalXml, 'utf-8');
     });
-  }).cb(cb);
 }
 
-function makeAndroidProject(api, app, opts, cb) {
+function makeAndroidProject(api, app, config, opts) {
   var projectPropertiesFile = path.join(opts.outputPath, 'project.properties');
-  var f = ff(function() {
-    fs.unlink(projectPropertiesFile, f.waitPlain()); // ignore error if file doesn't exist
-  }, function () {
-    spawnWithLogger(api, 'android', [
-      "create", "project", "--target", opts.target, "--name", opts.shortName,
-      "--path", opts.outputPath, "--activity", opts.activity,
-      "--package", opts.namespace
-    ], {}, f());
-  }, function() {
-    var tealeafDir = path.relative(opts.outputPath, path.join(__dirname, "TeaLeaf"));
-    spawnWithLogger(api, 'android', [
-      "update", "project", "--target", opts.target,
-      "--path", opts.outputPath,
-      "--library", tealeafDir
-    ], {}, f());
-  }, function() {
-    fs.appendFile(projectPropertiesFile, 'out.dexed.absolute.dir=../.dex/\nsource.dir=src\n',f());
-  }, function() {
-    var titles = opts.titles;
-    if (titles) {
-      if (titles.length == 0) {
-        titles['en'] = opts.title;
-      }
-    }  else {
-      titles = {};
-      titles['en'] = opts.title;
-    }
-    saveLocalizedStringsXmls(opts.outputPath, titles, f.wait());
-    updateManifest(api, app, opts, f.wait());
-    updateActivity(opts, f.wait());
-  }).cb(cb);
+  return fs.unlinkAsync(projectPropertiesFile)
+    .catch(function () {}) // ignore error if file doesn't exist
+    .then(function () {
+      return spawnWithLogger(api, 'android', [
+          "create", "project", "--target", ANDROID_TARGET, "--name", app.manifest.shortName,
+          "--path", opts.outputPath, "--activity", config.activityName,
+          "--package", config.packageName
+        ]);
+    })
+    .then(function () {
+      var tealeafDir = path.relative(opts.outputPath, path.join(__dirname, "TeaLeaf"));
+      return spawnWithLogger(api, 'android', [
+          "update", "project", "--target", ANDROID_TARGET,
+          "--path", opts.outputPath,
+          "--library", tealeafDir
+        ]);
+    })
+    .then(function () {
+      var dexDir = '\nout.dexed.absolute.dir=../.dex/\nsource.dir=src\n';
+      return [
+        fs.appendFileAsync(projectPropertiesFile, dexDir),
+        saveLocalizedStringsXmls(opts.outputPath, config.titles),
+        updateManifest(api, app, config, opts),
+        updateActivity(config, opts)
+      ];
+    })
+    .all();
 }
 
-function signAPK(api, shortName, outputPath, debug, cb) {
+function signAPK(api, shortName, outputPath, debug) {
   var signArgs, alignArgs;
   var binDir = path.join(outputPath, "bin");
 
-  logger.log('Signing APK at ', binDir);
+  logger.log('Signing APK at', binDir);
   if (debug) {
     var keyPath = path.join(process.env['HOME'], '.android', 'debug.keystore');
     signArgs = [
@@ -482,16 +422,16 @@ function signAPK(api, shortName, outputPath, debug, cb) {
       ];
   } else {
     var keystore = process.env['DEVKIT_ANDROID_KEYSTORE'];
-    if (!keystore) { throw new Error('missing environment variable DEVKIT_ANDROID_KEYSTORE'); }
+    if (!keystore) { throw new BuildError('missing environment variable DEVKIT_ANDROID_KEYSTORE'); }
 
     var storepass = process.env['DEVKIT_ANDROID_STOREPASS'];
-    if (!storepass) { throw new Error('missing environment variable DEVKIT_ANDROID_STOREPASS'); }
+    if (!storepass) { throw new BuildError('missing environment variable DEVKIT_ANDROID_STOREPASS'); }
 
     var keypass = process.env['DEVKIT_ANDROID_KEYPASS'];
-    if (!keypass) { throw new Error('missing environment variable DEVKIT_ANDROID_KEYPASS'); }
+    if (!keypass) { throw new BuildError('missing environment variable DEVKIT_ANDROID_KEYPASS'); }
 
     var key = process.env['DEVKIT_ANDROID_KEY'];
-    if (!key) { throw new Error('missing environment variable DEVKIT_ANDROID_KEY'); }
+    if (!key) { throw new BuildError('missing environment variable DEVKIT_ANDROID_KEY'); }
 
     signArgs = [
         "-sigalg", "MD5withRSA", "-digestalg", "SHA1",
@@ -505,11 +445,10 @@ function signAPK(api, shortName, outputPath, debug, cb) {
       ];
   }
 
-  var f = ff(function() {
-    spawnWithLogger(api, 'jarsigner', signArgs, {cwd: binDir}, f.wait());
-  }, function () {
-    spawnWithLogger(api, 'zipalign', alignArgs , {cwd: binDir}, f.wait());
-  }).cb(cb);
+  return spawnWithLogger(api, 'jarsigner', signArgs, {cwd: binDir})
+    .then(function () {
+      return spawnWithLogger(api, 'zipalign', alignArgs , {cwd: binDir});
+    });
 }
 
 function repackAPK(api, outputPath, apkName, cb) {
@@ -518,28 +457,22 @@ function repackAPK(api, outputPath, apkName, cb) {
     if (err) { return cb(err); }
     spawnWithLogger(api, 'zip', [apkPath, '-u'], {cwd: outputPath}, cb);
   });
-};
-
-var DEFAULT_ICON_PATH = {
-  "36": "drawable-ldpi/icon.png",
-  "48": "drawable-mdpi/icon.png",
-  "72": "drawable-hdpi/icon.png",
-  "96": "drawable-xhdpi/icon.png",
-  "144": "drawable-xxhdpi/icon.png"
-};
+}
 
 function copyIcons(app, outputPath) {
-  copyIcon(app, outputPath, "l", "36");
-  copyIcon(app, outputPath, "m", "48");
-  copyIcon(app, outputPath, "h", "72");
-  copyIcon(app, outputPath, "xh", "96");
-  copyIcon(app, outputPath, "xxh", "144");
-  copyIcon(app, outputPath, "xxxh", "192");
-  copyNotifyIcon(app, outputPath, "l", "low");
-  copyNotifyIcon(app, outputPath, "m", "med");
-  copyNotifyIcon(app, outputPath, "h", "high");
-  copyNotifyIcon(app, outputPath, "xh", "xhigh");
-  copyNotifyIcon(app, outputPath, "xxh", "xxhigh");
+  return Promise.all([
+      copyIcon(app, outputPath, "l", "36"),
+      copyIcon(app, outputPath, "m", "48"),
+      copyIcon(app, outputPath, "h", "72"),
+      copyIcon(app, outputPath, "xh", "96"),
+      copyIcon(app, outputPath, "xxh", "144"),
+      copyIcon(app, outputPath, "xxxh", "192"),
+      copyNotifyIcon(app, outputPath, "l", "low"),
+      copyNotifyIcon(app, outputPath, "m", "med"),
+      copyNotifyIcon(app, outputPath, "h", "high"),
+      copyNotifyIcon(app, outputPath, "xh", "xhigh"),
+      copyNotifyIcon(app, outputPath, "xxh", "xxhigh")
+    ]);
 }
 
 function copyIcon(app, outputPath, tag, size) {
@@ -549,99 +482,77 @@ function copyIcon(app, outputPath, tag, size) {
 
   if (iconPath) {
     iconPath = path.resolve(app.paths.root, iconPath);
-
-    if (fs.existsSync(iconPath)) {
-      wrench.mkdirSyncRecursive(path.dirname(destPath));
-      copyFileSync(iconPath, destPath);
-    }
-
-    return;
+    return fs.copyAsync(iconPath, destPath);
   }
 
-  logger.warn("No icon specified in the manifest for '", size, "'. Using the default icon for this size. This is probably not what you want");
+  logger.warn("No icon specified in the manifest for size '" + size + "'. Using the default icon for this size. This is probably not what you want.");
 }
-
-var DEFAULT_NOTIFY_ICON_PATH = {
-  "low": "drawable-ldpi/notifyicon.png",
-  "med": "drawable-mdpi/notifyicon.png",
-  "high": "drawable-hdpi/notifyicon.png",
-  "xhigh": "drawable-xhdpi/notifyicon.png",
-  "xxhigh": "drawable-xxhdpi/notifyicon.png"
-};
 
 function copyNotifyIcon(app, outputPath, tag, name) {
   var destPath = path.join(outputPath, "res/drawable-" + tag + "dpi/notifyicon.png");
-  wrench.mkdirSyncRecursive(path.dirname(destPath));
-
   var android = app.manifest.android;
   var iconPath = android && android.icons && android.icons.alerts && android.icons.alerts[name];
 
-  if (iconPath && fs.existsSync(iconPath)) {
-    copyFileSync(iconPath, destPath);
+  if (iconPath) {
+    return fs.copyAsync(iconPath, destPath);
   } else {
-    logger.warn("No alert icon specified in the manifest for '", name, "'");
-
     // Do not copy a default icon to this location -- Android will fill in
     // the blanks intelligently.
-    //copyFileSync(path.join(__dirname, "TeaLeaf/res", DEFAULT_NOTIFY_ICON_PATH[name]), destPath);
+    logger.warn("No alert icon specified in the manifest for density '" + name + "'");
   }
 }
 
-function copySplash(api, app, outputDir, next) {
-  var destPath = path.join(outputDir, "assets/resources");
-  wrench.mkdirSyncRecursive(destPath);
-
-  var splashes = [
-    {
-      copyFile: "portrait512",
-      inFiles: [
-        "portrait960",
-        "portrait1024",
-        "portrait1136",
-        "portrait480",
-        "universal",
-        "portrait2048"
-      ],
-      outFile: "splash-512.png",
-      outSize: "512"
-    },
-    {
-      copyFile: "portrait1024",
-      inFiles: [
-        "portrait1136",
-        "universal",
-        "portrait960",
-        "portrait2048"
+var DEFAULT_SPLASH_FILES = [
+  {
+    copyFile: "portrait512",
+    inFiles: [
+      "portrait960",
+      "portrait1024",
+      "portrait1136",
+      "portrait480",
+      "universal",
+      "portrait2048"
+    ],
+    outFile: "splash-512.png",
+    outSize: "512"
+  },
+  {
+    copyFile: "portrait1024",
+    inFiles: [
+      "portrait1136",
+      "universal",
+      "portrait960",
+      "portrait2048"
 /*        "portrait512",
-        "portrait480"*/
-      ],
-      outFile: "splash-1024.png",
-      outSize: "1024"
-    },
-    {
-      copyFile: "portrait2048",
-      inFiles: [
-        "universal"
+      "portrait480"*/
+    ],
+    outFile: "splash-1024.png",
+    outSize: "1024"
+  },
+  {
+    copyFile: "portrait2048",
+    inFiles: [
+      "universal"
 /*        "portrait1136",
-        "portrait1024",
-        "portrait960",
-        "portrait512",
-        "portrait480"*/
-      ],
-      outFile: "splash-2048.png",
-      outSize: "2048"
-    }
-  ];
+      "portrait1024",
+      "portrait960",
+      "portrait512",
+      "portrait480"*/
+    ],
+    outFile: "splash-2048.png",
+    outSize: "2048"
+  }
+];
 
+function copySplash(api, app, outputDir) {
   var splashPaths = app.manifest.splash || {};
-
-  var f = ff(function () {
-    var group = f.group();
-    var splasherTasks = [];
-
-    // For each splash image to produce,
-    for (var ii = 0; ii < splashes.length; ++ii) {
-      var splash = splashes[ii];
+  var splashTasks = [];
+  var destPath = path.join(outputDir, "assets/resources");
+  return fs.mkdirsAsync(destPath)
+    .then(function () {
+      return DEFAULT_SPLASH_FILES;
+    })
+    .map(function (splash) {
       var outFile = splash.outFile;
       var outSize = splash.outSize;
       var copyFile = splash.copyFile;
@@ -703,91 +614,86 @@ function copySplash(api, app, outputDir, next) {
         // If copying,
         if (copying) {
           logger.log("Copying size", outSize, "splash:", outFile, "from", srcFile);
-
-          copyFileSync(srcFile, outFile);
+          return fs.copyAsync(srcFile, outFile);
         } else {
-          splasherTasks.push({
+          splashTasks.push({
             'outSize': outSize,
             'outFile': outFile,
             'srcFile': srcFile
           });
         }
       } // end if input file exists
-    } // next splash screen
-
-    // Run splasher one at a time because the jvm tool is unable to run multiple
-    // instances of the same Java application in parallel.  FIXME
-    function runSplasher() {
-      var task = splasherTasks.pop();
-      if (!task) {
-        return;
-      }
-
-      var slot = group();
+    })
+    .then(function () {
+      return splashTasks;
+    })
+    .map(function (task) {
+      if (!task) { return; }
 
       logger.log("Creating size", task.outSize, "splash:", task.outFile, "from", task.srcFile);
 
-      api.jvmtools.exec({
-        tool: 'splasher',
-        args: [
-          "-i", task.srcFile,
-          "-o", task.outFile,
-          "-resize", task.outSize,
-          "-rotate", "auto"
-        ]
-      }, function (err, splasher) {
-        var logger = api.logging.get('splash' + task.outSize);
-        splasher.on('out', logger.out);
-        splasher.on('err', logger.err);
-        splasher.on('end', function (data) {
-          logger.log("Done splashing size", task.outSize);
-          runSplasher();
-          slot();
+      return new Promise(function (resolve, reject) {
+        // Run splasher one at a time because the jvm tool is unable to run multiple
+        // instances of the same Java application in parallel.  FIXME
+        api.jvmtools.exec({
+          tool: 'splasher',
+          args: [
+            "-i", task.srcFile,
+            "-o", task.outFile,
+            "-resize", task.outSize,
+            "-rotate", "auto"
+          ]
+        }, function (err, splasher) {
+          if (err) { return reject(err); }
+
+          var logger = api.logging.get('splash' + task.outSize);
+          splasher.on('out', logger.out);
+          splasher.on('err', logger.err);
+          splasher.on('end', function () {
+            logger.log("Done splashing size", task.outSize);
+            resolve();
+          });
         });
       });
-    }
-
-    // Run splasher on tasks
-    runSplasher();
-  }).cb(next);
+    }, {concurrency: 1});
 }
 
-function copyMusic(app, outputDir, cb) {
+function copyMusic(app, outputDir) {
   if (app.manifest.splash) {
-    var destPath = path.join(outputDir, "res/raw");
-    mkdirp(destPath, function () {
-      var musicPath = app.manifest.splash.song;
-      if (musicPath && fs.existsSync(musicPath)) {
-        copyFileSync(musicPath, path.join(destPath, "loadingsound.mp3"));
-      } else {
-        logger.warn("No splash music specified in the manifest");
-      }
-    });
+    var musicPath = app.manifest.splash.song;
+    var destPath = path.join(outputDir, "res/raw", "loadingsound.mp3");
+    return existsAsync(musicPath)
+      .then(function (exists) {
+        if (!exists) {
+          logger.warn('No valid splash music specified in the manifest (at "splash.song")');
+        } else {
+          return fs.copyAsync(musicPath, destPath);
+        }
+      });
   }
-  cb && cb();
 }
 
 function copyResDir(app, outputDir) {
   if (app.manifest.android && app.manifest.android.resDir) {
     var destPath = path.join(outputDir, "res");
     var sourcePath = path.resolve(app.manifest.android.resDir);
-    try {
-      wrench.copyDirSyncRecursive(sourcePath, destPath, {preserve: true});
-    } catch (e) {
-      logger.warn("Could not copy your android resource dir [" + e.toString() + "]");
-    }
+    return fs.copyAsync(sourcePath, destPath, {preserveTimestamps: true})
+      .catch(function (e) {
+        logger.warn("Could not copy your android resource dir [" + e.toString() + "]");
+        throw e;
+      });
   }
 }
 
-function updateManifest(api, app, opts, cb) {
-  var defaults = {
+function updateManifest(api, app, config, opts) {
+  var params = {
     // Empty defaults
     installShortcut: "false",
 
     entryPoint: "devkit.native.launchClient",
-    studioName: opts.studioName,
+    studioName: config.studioName,
 
-    disableLogs: String(!opts.debug),
+    disableLogs: config.debug ? 'false' : 'true',
 
     // Filled defaults
     // TODO: REMOVE ALL OF THESE FLAGS
@@ -798,347 +704,292 @@ function updateManifest(api, app, opts, cb) {
     activePollTimeInSeconds: "10",
     passivePollTimeInSeconds: "20",
     syncPolling: "false",
-    develop: String(opts.debug),
+    develop: config.debug ? 'true' : 'false',
   };
 
-  var f = ff(function() {
-    versionCode(app, opts.debug, f());
-  }, function(versionCode) {
-    var orientations = app.manifest.supportedOrientations;
-    var orientation = "portrait";
+  var orientations = app.manifest.supportedOrientations;
+  var orientation = "portrait";
 
-    if (orientations.indexOf("portrait") != -1 && orientations.indexOf("landscape") != -1) {
-      orientation = "unspecified";
-    } else if (orientations.indexOf("landscape") != -1) {
-      orientation = "landscape";
+  if (orientations.indexOf("portrait") != -1 && orientations.indexOf("landscape") != -1) {
+    orientation = "unspecified";
+  } else if (orientations.indexOf("landscape") != -1) {
+    orientation = "landscape";
+  }
+
+  function copy(target, src) {
+    for (var key in src) {
+      target[key] = src[key];
     }
+  }
 
-    function copy(target, src) {
-      for (var key in src) {
-        target[key] = src[key];
+  function copyAndFlatten(target, src, prefix) {
+    prefix = prefix || '';
+
+    for (var key in src) {
+      var val = src[key];
+      var newPrefix = prefix.length === 0 ? key : prefix + '.' + key;
+      if(typeof val === "object") {
+        copyAndFlatten(target, val, newPrefix);
+      } else {
+        // Push to final object
+        target[newPrefix] = val;
       }
     }
+  }
 
-    function copyAndFlatten(target, src, prefix) {
-      prefix = prefix || '';
+  copy(params, app.manifest.android);
+  copyAndFlatten(params, app.manifest.modules || app.manifest.addons);
+  copy(params, {
+    "package": config.packageName,
+    title: "@string/title",
+    activity: config.packageName + "." + config.activityName,
+    version: "" + config.version,
+    appid: app.manifest.appID.replace(PUNCTUATION_REGEX, ""), // Strip punctuation.,
+    shortname: app.manifest.shortName,
+    orientation: orientation,
+    studioName: config.studioName,
+    gameHash: app.manifest.version,
+    sdkHash: config.sdkVersion,
+    androidHash: androidVersion,
+    debuggable: config.debug ? 'true' : 'false'
+  });
 
-      for (var key in src) {
-        var val = src[key];
-        var newPrefix = prefix.length === 0 ? key : prefix + '.' + key;
-        if(typeof val === "object") {
-          copyAndFlatten(target, val, newPrefix);
-        } else {
-          // Push to final object
-          target[newPrefix] = val;
-        }
-      }
-
-    }
-
-    function rename(target, oldKey, newKey) {
-      if ('oldKey' in target) {
-        target[newKey] = target[oldKey];
-        delete target[newKey];
-      }
-    }
-
-    function explode(target, key, mapping) {
-      if (key in target) {
-        for (var subKey in mapping) {
-          if (target[key][subKey]) {
-            target[mapping[subKey]] = target[key][subKey];
-          }
-        }
-
-        delete target[key];
-      }
-    }
-
-    var gameVersion = require(path.join(app.paths.root, 'manifest.json')).version;
-
-    var params = {};
-    f(params);
-    copy(params, defaults);
-    copy(params, app.manifest.android);
-    copyAndFlatten(params, app.manifest.modules || app.manifest.addons);
-    copy(params, {
-      "package": opts.namespace,
-      title: "@string/title",
-      activity: opts.namespace + "." + opts.activity,
-      version: "" + opts.version,
-      appid: opts.appID,
-      shortname: opts.shortName,
-      orientation: orientation,
-      studioName: opts.studioName,
-      gameHash: gameVersion,
-      sdkHash: opts.sdkVersion,
-      androidHash: androidVersion,
-      versionCode: versionCode,
-      debuggable: opts.debug ? 'true' : 'false'
-    });
-
-    wrench.mkdirSyncRecursive(opts.outputPath);
-
-  }, function(params) {
-    f(params);
-
-    fs.readFile(path.join(__dirname, "TeaLeaf/AndroidManifest.xml"), "utf-8", f());
-  }, function(params, xmlContent) {
-    f(params);
-
-    fs.writeFile(path.join(opts.outputPath, "AndroidManifest.xml"), xmlContent, "utf-8", f.wait());
-  }, function(params) {
-    f(params);
-
-    injectPluginXML(opts, f());
-  }, function(params) {
-    f(params);
-
-    var xmlPath = path.join(opts.outputPath, "AndroidManifest.xml");
-
-    var xslPaths = [];
-
-    for (var moduleName in opts.moduleConfig) {
+  var defaultManifest = path.join(__dirname, "TeaLeaf/AndroidManifest.xml");
+  var outputManifest = path.join(opts.outputPath, "AndroidManifest.xml");
+  Promise.all([
+      fs.copyAsync(defaultManifest, outputManifest),
+      getVersionCode(app, config.debug)
+        .then(function(versionCode) {
+          params.versionCode = versionCode;
+        })
+    ])
+    .then(function () {
+      return injectPluginXML(opts);
+    })
+    .then(function () {
+      return Object.keys(opts.moduleConfig);
+    })
+    .map(function (moduleName) {
       var module = opts.moduleConfig[moduleName];
       var config = module.config;
       if (config.injectionXSL) {
         var xslPath = path.join(module.path, 'android', config.injectionXSL);
-        xslPaths.push(xslPath);
+        return transformXSL(api, outputManifest, outputManifest, xslPath, params);
       }
-    }
-
-    // Run the plugin XSLT in series instead of parallel
-    if (xslPaths.length > 0) {
-      var allDone = f.wait();
-
-      var runPluginXSLT = function(index) {
-        if (index >= xslPaths.length) {
-          allDone();
-        } else {
-          var xslPath = xslPaths[index];
-
-          logger.log("Transforming XML with plugin XSL for", xslPath);
-
-          transformXSL(api, xmlPath, xmlPath, xslPath, params, function (err) {
-            if (err) {
-              return allDone(err);
-            }
-
-            runPluginXSLT(index + 1);
-          });
-        }
-      }
-
-      runPluginXSLT(0);
-    }
-  }, function(params) {
-    logger.log("Applying final XSL transformation");
-    f(params);
-
-    var xmlPath = path.join(opts.outputPath, "AndroidManifest.xml");
-    transformXSL(api, xmlPath, xmlPath,
-        path.join(__dirname, "AndroidManifest.xsl"),
-        params, f());
-  }).cb(cb);
+    }, {concurrency: 1}) // Run the plugin XSLT in series instead of parallel
+    .then(function() {
+      logger.log("Applying final XSL transformation");
+      var xmlPath = path.join(opts.outputPath, "AndroidManifest.xml");
+      return transformXSL(api, xmlPath, xmlPath,
+          path.join(__dirname, "AndroidManifest.xsl"),
+          params);
+    });
 }
 
-function versionCode(app, debug, cb) {
+function getVersionCode(app, debug) {
   var versionPath = path.join(app.paths.root, '.version');
+  var versionCode = '0'; // debug version is code 0
+  return fs.readFileAsync(versionPath)
+    .catch(function (err) {
+      if (err && err.code == 'ENOENT') {
+        var contents = '0';
+        return fs.writeFileAsync(versionPath, contents)
+          .return(contents);
+      } else {
+        throw err;
+      }
+    })
+    .then(function (contents) {
+      var version = parseInt(contents, 10);
+      if (isNaN(version)) {
+        throw new BuildError('Invalid ".version" file. It must contain a single integer.');
+      }
 
-  var f = ff(this, function() {
-    fs.exists(versionPath, f.slotPlain());
-  }, function (exists) {
-    if (!exists) {
-      fs.writeFile(versionPath, '0', f.wait());
-    }
-  }, function() {
-    //read the version
-    fs.readFile(versionPath, f());
-  }, function(readVersion) {
-    var version = parseInt(readVersion, 10);
-
-    if (isNaN(version)) {
-      throw new Error(".version file seems incorrect. Make sure it's correctly formatted");
-    }
-
-    if (!debug) {
-      ++version;
-      fs.writeFile(versionPath, version, f.wait());
-    }
-
-    f(version);
-  }).error(function(err) {
-    if (!debug) {
-      logger.error("Could not get version code");
-    }
-  }).cb(cb);
+      if (!debug) {
+        ++version;
+        versionCode = '' + version;
+        logger.log(chalk.yellow('** release versionCode set to ' + versionCode));
+        return fs.writeFileAsync(versionPath, versionCode);
+      }
+    })
+    .catch(function (err) {
+      if (!debug) {
+        // version code only needed for release builds, ignore errors in debug
+        throw err;
+      }
+    })
+    .then(function () {
+      return versionCode;
+    });
 }
 
-function updateActivity(opts, next) {
-  var activityFile = path.join(opts.outputPath, "src/" + opts.namespace.replace(/\./g, "/") + "/" + opts.activity + ".java");
+function updateActivity(config, opts) {
+  var activityFile = path.join(opts.outputPath,
+      "src",
+      config.packageName.replace(/\./g, "/"),
+      config.activityName + ".java");
 
-  if (fs.existsSync(activityFile)) {
-    fs.readFile(activityFile, 'utf-8', function (err, contents) {
+  return fs.readFileAsync(activityFile, 'utf-8')
+    .then(function (contents) {
       contents = contents
         .replace(/extends Activity/g, "extends com.tealeaf.TeaLeaf")
         .replace(/setContentView\(R\.layout\.main\);/g, "startGame();");
-      fs.writeFile(activityFile, contents, next);
+      return fs.writeFileAsync(activityFile, contents);
     });
-  }
+}
+
+function createProject(api, app, config) {
+
+  var tasks = [];
+  tasks.push(getModuleConfig(api, app)
+    .then(function (moduleConfig) {
+      return makeAndroidProject(api, app, config, {
+          outputPath: config.outputPath,
+          moduleConfig: moduleConfig
+        })
+        .return(moduleConfig);
+    })
+    .then(function (moduleConfig) {
+      return installModuleCode(api, app, {
+          moduleConfig: moduleConfig,
+          outputPath: config.outputPath
+        });
+    }));
+
+  // TODO: if build switches between release to debug, clean project
+  // var cleanProj = (builder.common.config.get("lastBuildWasDebug") != config.debug) || config.clean;
+  // builder.common.config.set("lastBuildWasDebug", config.debug);
+
+  tasks.push(buildSupportProjects(api, config));
+
+  return Promise.all(tasks);
 }
 
 exports.build = function(api, app, config, cb) {
-  logger = api.logging.get('native-android');
+  logger = api.logging.get('android');
 
   var argv = config.argv;
 
-  // Extracted values from options.
-  var packageName = config.packageName;
+  var skipAPK = argv.apk === false;
+  var skipSigning = skipAPK || argv.signing === false || config.debug;
 
-  // Extract manifest properties.
-  var appID = app.manifest.appID;
   var shortName = app.manifest.shortName;
-  // Verify they exist.
-  if (appID === null || shortName === null) {
-    throw new Error("Build aborted: No appID or shortName in the manifest");
+  if (shortName === null) {
+    throw new BuildError("Build aborted: No shortName in the manifest");
   }
 
-  appID = appID.replace(PUNCTUATION_REGEX, ""); // Strip punctuation.
-
-  // app title
-  var title = app.manifest.title;
-  var titles = app.manifest.titles;
-  if (title === null && titles === null) {
-    title = shortName;
-  }
-
-  var studioName = app.manifest.studio && app.manifest.studio.name;
-
-  // Create Android Activity name.
-  var activity = shortName + "Activity";
-  var androidTarget = "android-19";
-
-  var apkPath;
-  var moduleConfig;
   var apkBuildName = "";
   if (!config.debug) {
     apkBuildName = shortName + "-aligned.apk";
   } else {
     apkBuildName = shortName + "-debug.apk";
   }
-  var f = ff(function () {
-    if (!config.repack) {
-      getModuleConfig(api, app, config, f());
-    }
-  }, function (_moduleConfig) {
-    moduleConfig = _moduleConfig;
 
-    if (!config.repack) {
-      makeAndroidProject(api, app, {
-        namespace: packageName,
-        activity: activity,
-        title: title,
-        appID: appID,
-        shortName: shortName,
-        version: config.version,
-        debug: config.debug,
-        outputPath: config.outputPath,
-        studioName: studioName,
-        moduleConfig: moduleConfig,
-        enableLogging: config.enableLogging,
-        titles: titles,
-        target: androidTarget,
-        sdkVersion: config.sdkVersion
-      }, f());
+  return Promise.try(function createAndroidProjectFiles() {
+      if (!config.repack) {
+        return createProject(api, app, config);
+      }
+    })
+    .then(function copyResourcesToProject() {
+      return [
+        copyIcons(app, config.outputPath),
+        copyMusic(app, config.outputPath),
+        copyResDir(app, config.outputPath),
+        copySplash(api, app, config.outputPath)
+      ];
+    })
+    .all()
+    .then(function buildAPK() {
+      if (!skipAPK) {
+        if (config.repack) {
+          return repackAPK(api, config.outputPath, apkBuildName);
+        } else {
+          var antScheme = (config.debug ? "debug" : "release");
+          return spawnWithLogger(api, 'ant', [antScheme], {
+              cwd: config.outputPath
+            });
+        }
+      }
+    })
+    .then(function () {
+      if (!skipSigning) {
+        return signAPK(api, shortName, config.outputPath, config.debug);
+      }
+    })
+    .then(function () {
+      if (!skipAPK) {
+        return moveAPK(api, app, config, apkBuildName)
+          .tap(function (apkPath) {
+            logger.log("built", chalk.yellow(config.packageName));
+            logger.log("saved to " + chalk.blue(apkPath));
+          })
+          .then(function (apkPath) {
+            if (argv.reveal) {
+              require('child_process').exec('open --reveal "' + apkPath + '"');
+            }
 
-      // TODO: if build switches between release to debug, clean project
-      // var cleanProj = (builder.common.config.get("lastBuildWasDebug") != config.debug) || config.clean;
-      // builder.common.config.set("lastBuildWasDebug", config.debug);
-      buildSupportProjects(api, {
-        outputPath: config.outputPath,
-        debug: config.debug,
-        arch: argv.arch,
-        clean: config.clean
-      }, f());
-    }
-  }, function() {
-    copyIcons(app, config.outputPath);
-    copyMusic(app, config.outputPath, f());
-    copyResDir(app, config.outputPath);
-    copySplash(api, app, config.outputPath, f());
-
-    if (!config.repack) {
-      installModuleCode(api, app, {
-        moduleConfig: moduleConfig,
-        outputPath: config.outputPath,
-        target: androidTarget
-      }, f());
-    }
-  }, function () {
-    if (!config.repack) {
-      spawnWithLogger(api, 'ant', [(config.debug ? "debug" : "release")], {
-          cwd: config.outputPath
-        }, f());
-    } else if(!argv.noapk) {
-      repackAPK(api, config.outputPath, apkBuildName, f());
-    }
-  }, function () {
-    if (!argv.noapk) {
-      if (!config.debug || config.repack) {
-        signAPK(api, shortName, config.outputPath, config.debug, f());
+            if (argv.install || argv.open) {
+              return installAPK(api, config, apkPath, {
+                open: !!argv.open,
+                clearStorage: argv.clearStorage
+              });
+            }
+          });
       }
-    }
-  }, function () {
-    if (!argv.noapk) {
-      apkPath = path.join(config.outputPath, shortName + ".apk");
-      if (fs.existsSync(apkPath)) {
-        fs.unlinkSync(apkPath);
-      }
-      var destApkPath = path.join(config.outputPath, "bin", apkBuildName);
-      if (fs.existsSync(destApkPath)) {
-        wrench.mkdirSyncRecursive(path.dirname(apkPath), 0777);
-        copyFileSync(destApkPath, apkPath);
-        logger.log("built", clc.yellowBright(packageName));
-        logger.log("saved to " + clc.blueBright(apkPath));
-      } else {
-        logger.error("No file at " + destApkPath);
-        next(2);
-      }
-    }
-  }, function() {
-    if (!argv.noapk) {
-      if (argv.install || argv.open) {
-        var keepStorage = argv.clearstorage ? "" : "-k";
-        var cmd = 'adb uninstall ' + keepStorage + ' "' + packageName + '"';
-        logger.log('Install: Running ' + cmd + '...');
-        var argz = ['shell', 'pm', 'uninstall'];
-        keepStorage && argz.push(keepStorage);
-        argz.push(packageName);
-        spawnWithLogger(api, 'adb', argz, {}, f.waitPlain()); //this is waitPlain because it can fail and not break.
-      }
-    }
-  }, function() {
-    if (!argv.noapk) {
-      if (argv.install || argv.open) {
-        var cmd = 'adb install -r "' + apkPath + '"';
-        logger.log('Install: Running ' + cmd + '...');
-        spawnWithLogger(api, 'adb', ['install', '-r', apkPath], {}, f.waitPlain()); //this is waitPlain because it can fail and not break.
-      }
-    }
-  }, function () {
-    if (!argv.noapk) {
-      if (argv.open) {
-        var startCmd = packageName + '/' + packageName + '.' + shortName + 'Activity';
-        var cmd = 'adb shell am start -n ' + startCmd;
-        logger.log('Install: Running ' + cmd + '...');
-        spawnWithLogger(api, 'adb', ['shell', 'am', 'start', '-n', startCmd], {}, f.waitPlain()); //this is waitPlain because it can fail and not break.
-      }
-
-      if (argv.reveal) {
-        require('child_process').exec('open --reveal "' + apkPath + '"');
-      }
-    }
-
-    f(config.outputPath);
-  }).cb(cb);
+    })
+    .nodeify(cb);
 };
+
+function moveAPK(api, app, config, apkBuildName) {
+  var shortName = app.manifest.shortName;
+  var apkPath = path.join(config.outputPath, shortName + ".apk");
+  var destApkPath = path.join(config.outputPath, "bin", apkBuildName);
+  return Promise.all([
+      existsAsync(destApkPath),
+      fs.unlinkAsync(apkPath)
+        .catch(function () {}) // ignore if it didn't exist
+    ])
+    .spread(function (exists) {
+      if (exists) {
+        return fs.copyAsync(destApkPath, apkPath);
+      } else {
+        throw new BuildError("apk failed to build (missing " + destApkPath + ")");
+      }
+    })
+    .return(destApkPath);
+}
+
+function installAPK(api, config, apkPath, opts) {
+  var packageName = config.packageName;
+  var activityName = config.activityName;
+
+  return Promise.try(function tryUninstall() {
+      var args = ['shell', 'pm', 'uninstall'];
+      if (opts.clearstorage) {
+        args.push('-k');
+      }
+      args.push(packageName);
+
+      return spawnWithLogger(api, 'adb', args, {})
+        .catch (function () {
+          // ignore uninstall errors
+        });
+    })
+    .then(function tryInstall() {
+      var cmd = 'adb install -r "' + apkPath + '"';
+      logger.log('Install: Running ' + cmd + '...');
+      return spawnWithLogger(api, 'adb', ['install', '-r', apkPath])
+        .catch (function () {
+          // ignore install errors
+        });
+    })
+    .then(function tryOpen() {
+      if (opts.open) {
+        var startCmd = packageName + '/' + packageName + '.' + activityName;
+        spawnWithLogger(api, 'adb', ['shell', 'am', 'start', '-n', startCmd], {})
+          .catch (function () {
+            // ignore open errors
+          });
+      }
+    });
+}

--- a/build.js
+++ b/build.js
@@ -478,7 +478,7 @@ function copyIcons(app, outputPath) {
 function copyIcon(app, outputPath, tag, size) {
   var destPath = path.join(outputPath, "res/drawable-" + tag + "dpi/icon.png");
   var android = app.manifest.android;
-  var iconPath = android && android.icons && android.icons[size];
+  var iconPath = android.icons && android.icons[size];
 
   if (iconPath) {
     iconPath = path.resolve(app.paths.root, iconPath);
@@ -491,7 +491,7 @@ function copyIcon(app, outputPath, tag, size) {
 function copyNotifyIcon(app, outputPath, tag, name) {
   var destPath = path.join(outputPath, "res/drawable-" + tag + "dpi/notifyicon.png");
   var android = app.manifest.android;
-  var iconPath = android && android.icons && android.icons.alerts && android.icons.alerts[name];
+  var iconPath = android.icons && android.icons.alerts && android.icons.alerts[name];
 
   if (iconPath) {
     return fs.copyAsync(iconPath, destPath);
@@ -674,7 +674,7 @@ function copyMusic(app, outputDir) {
 }
 
 function copyResDir(app, outputDir) {
-  if (app.manifest.android && app.manifest.android.resDir) {
+  if (app.manifest.android.resDir) {
     var destPath = path.join(outputDir, "res");
     var sourcePath = path.resolve(app.manifest.android.resDir);
     return fs.copyAsync(sourcePath, destPath, {preserveTimestamps: true})
@@ -883,6 +883,12 @@ exports.build = function(api, app, config, cb) {
     apkBuildName = shortName + "-aligned.apk";
   } else {
     apkBuildName = shortName + "-debug.apk";
+  }
+
+  if (!app.manifest.android) {
+    logger.warn('you should add an "android" key to your app\'s manifest.json',
+                'for android-specific settings');
+    app.manifest.android = {};
   }
 
   return Promise.try(function createAndroidProjectFiles() {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "description": "Native-Android DevKit addon for building for the Android platform",
   "version": "1.0.22",
   "dependencies": {
-    "cli-color": ">=0.2.2",
-    "ff": "0.2.0",
-    "mkdirp": "^0.5.0",
-    "wrench": "~1.3.9"
+    "bluebird": "^2.9.34",
+    "chalk": "^1.1.1",
+    "fs-extra": "^0.23.1"
   },
   "scripts": {
     "preinstall": "sh ./preinstall.sh",


### PR DESCRIPTION
 - `--install` and `--open` now work if multiple devices are connected
 - splash screens are copied without modification, runtime code determines which splash screen to use
 - improved logging
     - logs errors about sdk missing or correct api level not installed
 - adds `--target-sdk-version` and `--min-sdk-version` configuration to cli
 - replaces `ff` with `bluebird`, converts most (but not all) sync functions to async functions
     - except where otherwise noted here, the attempt was to preserve existing functionality and logic
 - fixes #28, #26, #21
