### PR TITLE
Pass memory warning to texture manager

### DIFF
--- a/TeaLeaf/jni/platform/native_shim.cpp
+++ b/TeaLeaf/jni/platform/native_shim.cpp
@@ -253,6 +253,10 @@ extern "C" {
         texture_manager_memory_warning();
     }
 
+    void Java_com_tealeaf_NativeShim_textureManagerMemoryCritical(JNIEnv *env, jobject thiz) {
+        texture_manager_memory_critical();
+    }
+
     void Java_com_tealeaf_NativeShim_textureManagerSetMaxMemory(JNIEnv *env, jobject thiz, jint bytes) {
         texture_manager_set_max_memory(texture_manager_get(), bytes);
     }

--- a/TeaLeaf/jni/platform/native_shim.cpp
+++ b/TeaLeaf/jni/platform/native_shim.cpp
@@ -249,6 +249,10 @@ extern "C" {
         texture_manager_clear_textures(texture_manager_get(), true);
     }
 
+    void Java_com_tealeaf_NativeShim_textureManagerMemoryWarning(JNIEnv *env, jobject thiz) {
+        texture_manager_memory_warning();
+    }
+
     void Java_com_tealeaf_NativeShim_textureManagerSetMaxMemory(JNIEnv *env, jobject thiz, jint bytes) {
         texture_manager_set_max_memory(texture_manager_get(), bytes);
     }

--- a/TeaLeaf/src/com/tealeaf/NativeShim.java
+++ b/TeaLeaf/src/com/tealeaf/NativeShim.java
@@ -510,6 +510,7 @@ public class NativeShim {
 
 	public native static void textureManagerSetMaxMemory(int bytes);
 	public native static void textureManagerMemoryWarning();
+	public native static void textureManagerMemoryCritical();
 
 	//LocalStorage
 	public void setData(String key, String data) {

--- a/TeaLeaf/src/com/tealeaf/NativeShim.java
+++ b/TeaLeaf/src/com/tealeaf/NativeShim.java
@@ -509,6 +509,7 @@ public class NativeShim {
 	public static native void dispatchContactCallback(int cb, long id, String name);
 
 	public native static void textureManagerSetMaxMemory(int bytes);
+	public native static void textureManagerMemoryWarning();
 
 	//LocalStorage
 	public void setData(String key, String data) {

--- a/TeaLeaf/src/com/tealeaf/TeaLeaf.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeaf.java
@@ -89,7 +89,7 @@ import org.json.JSONObject;
  * Longer term, this activity should become the activity that always starts and
  * then figures out which game activity to run.
  */
-public class TeaLeaf extends FragmentActivity implements ComponentCallbacks2 {
+public class TeaLeaf extends FragmentActivity {
 	private TeaLeafOptions options;
 
 	public TeaLeafGLSurfaceView glView;

--- a/TeaLeaf/src/com/tealeaf/TeaLeaf.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeaf.java
@@ -39,6 +39,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.ComponentCallbacks2;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.content.SharedPreferences.Editor;
@@ -88,7 +89,7 @@ import org.json.JSONObject;
  * Longer term, this activity should become the activity that always starts and
  * then figures out which game activity to run.
  */
-public class TeaLeaf extends FragmentActivity {
+public class TeaLeaf extends FragmentActivity implements ComponentCallbacks2 {
 	private TeaLeafOptions options;
 
 	public TeaLeafGLSurfaceView glView;
@@ -982,6 +983,20 @@ public class TeaLeaf extends FragmentActivity {
 
 	static {
 		System.loadLibrary("tealeaf");
+	}
+
+	@Override
+	public void onLowMemory() {
+		if (glView != null) {
+			glView.onMemoryWarning(TRIM_MEMORY_COMPLETE);
+		}
+	}
+
+	@Override
+	public void onTrimMemory(int level) {
+		if (glView != null) {
+			glView.onMemoryWarning(level);
+		}
 	}
 
 }

--- a/TeaLeaf/src/com/tealeaf/TeaLeaf.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeaf.java
@@ -988,7 +988,7 @@ public class TeaLeaf extends FragmentActivity implements ComponentCallbacks2 {
 	@Override
 	public void onLowMemory() {
 		if (glView != null) {
-			glView.onMemoryWarning(TRIM_MEMORY_COMPLETE);
+			NativeShim.textureManagerMemoryCritical();
 		}
 	}
 

--- a/TeaLeaf/src/com/tealeaf/TeaLeaf.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeaf.java
@@ -39,7 +39,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.ComponentCallbacks2;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.content.SharedPreferences.Editor;

--- a/TeaLeaf/src/com/tealeaf/TeaLeafApplication.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeafApplication.java
@@ -16,24 +16,11 @@ package com.tealeaf;
 import android.app.Application;
 import android.content.Context;
 import com.tealeaf.plugin.PluginManager;
-import android.content.ComponentCallbacks2;
 
-public class TeaLeafApplication extends Application implements ComponentCallbacks2 {
+public class TeaLeafApplication extends Application {
 	@Override
 	public void onCreate() {
 		PluginManager.init(this);
 		PluginManager.callAll("onCreateApplication", this.getApplicationContext());
-	}
-
-	@Override
-	public void onLowMemory() {
-		NativeShim.textureManagerMemoryWarning();
-	}
-
-	@Override
-	public void onTrimMemory(int level) {
-		if (level == TRIM_MEMORY_RUNNING_CRITICAL) {
-			NativeShim.textureManagerMemoryWarning();
-		}
 	}
 }

--- a/TeaLeaf/src/com/tealeaf/TeaLeafApplication.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeafApplication.java
@@ -16,12 +16,24 @@ package com.tealeaf;
 import android.app.Application;
 import android.content.Context;
 import com.tealeaf.plugin.PluginManager;
+import android.content.ComponentCallbacks2;
 
-public class TeaLeafApplication extends  Application {
+public class TeaLeafApplication extends Application implements ComponentCallbacks2 {
 	@Override
 	public void onCreate() {
 		PluginManager.init(this);
 		PluginManager.callAll("onCreateApplication", this.getApplicationContext());
 	}
 
+	@Override
+	public void onLowMemory() {
+		NativeShim.textureManagerMemoryWarning();
+	}
+
+	@Override
+	public void onTrimMemory(int level) {
+		if (level == TRIM_MEMORY_RUNNING_CRITICAL) {
+			NativeShim.textureManagerMemoryWarning();
+		}
+	}
 }

--- a/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
@@ -105,10 +105,12 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 		};
 		orientationListener.enable();
 
-		final ActivityManager activityManager = (ActivityManager) TeaLeaf.get().getSystemService(Context.ACTIVITY_SERVICE);
-		ActivityManager.RunningAppProcessInfo currentState = activityManager.getRunningAppProcesses().get(0);
-		ActivityManager.getMyMemoryState(currentState);
-		onMemoryWarning(currentState.lastTrimLevel);
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+			final ActivityManager activityManager = (ActivityManager) TeaLeaf.get().getSystemService(Context.ACTIVITY_SERVICE);
+			ActivityManager.RunningAppProcessInfo currentState = activityManager.getRunningAppProcesses().get(0);
+			ActivityManager.getMyMemoryState(currentState);
+			onMemoryWarning(currentState.lastTrimLevel);
+		}
 	}
 
 	public OnTouchListener getOnTouchListener() {

--- a/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
@@ -26,6 +26,9 @@ import android.os.Build;
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
 
+import android.app.ActivityManager;
+import android.content.ComponentCallbacks2;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
@@ -101,6 +104,11 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 			}
 		};
 		orientationListener.enable();
+
+		final ActivityManager activityManager = (ActivityManager) TeaLeaf.get().getSystemService(Context.ACTIVITY_SERVICE);
+		ActivityManager.RunningAppProcessInfo currentState = activityManager.getRunningAppProcesses().get(0);
+		ActivityManager.getMyMemoryState(currentState);
+		onMemoryWarning(currentState.lastTrimLevel);
 	}
 
 	public OnTouchListener getOnTouchListener() {
@@ -312,6 +320,14 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 
 	public TextureLoader getTextureLoader() {
 		return renderer.getTextureLoader();
+	}
+
+	public void onMemoryWarning(int level) {
+		if (level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+			NativeShim.textureManagerMemoryCritical();
+		} else if (level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
+			NativeShim.textureManagerMemoryWarning();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
If we don't handle android system's memory warning, it will kill the app.

This issue is pretty frequent when user is having a device which
currently has very low free memory. Passing the warning to native will
help us to remove textures or even half size it.

This is already being done in iOS.