### PR TITLE
Better way to handle memory warnings

### DIFF
--- a/TeaLeaf/jni/platform/native_shim.cpp
+++ b/TeaLeaf/jni/platform/native_shim.cpp
@@ -258,7 +258,7 @@ extern "C" {
     }
 
     void Java_com_tealeaf_NativeShim_textureManagerResetMemoryCritical(JNIEnv *env, jobject thiz) {
-        texture_manager_memory_reset_memory_critical();
+        texture_manager_reset_memory_critical();
     }
 
     void Java_com_tealeaf_NativeShim_textureManagerSetMaxMemory(JNIEnv *env, jobject thiz, jint bytes) {

--- a/TeaLeaf/jni/platform/native_shim.cpp
+++ b/TeaLeaf/jni/platform/native_shim.cpp
@@ -257,6 +257,10 @@ extern "C" {
         texture_manager_memory_critical();
     }
 
+    void Java_com_tealeaf_NativeShim_textureManagerMemoryReset(JNIEnv *env, jobject thiz) {
+        texture_manager_memory_reset();
+    }
+
     void Java_com_tealeaf_NativeShim_textureManagerSetMaxMemory(JNIEnv *env, jobject thiz, jint bytes) {
         texture_manager_set_max_memory(texture_manager_get(), bytes);
     }

--- a/TeaLeaf/jni/platform/native_shim.cpp
+++ b/TeaLeaf/jni/platform/native_shim.cpp
@@ -257,8 +257,8 @@ extern "C" {
         texture_manager_memory_critical();
     }
 
-    void Java_com_tealeaf_NativeShim_textureManagerMemoryReset(JNIEnv *env, jobject thiz) {
-        texture_manager_memory_reset();
+    void Java_com_tealeaf_NativeShim_textureManagerResetMemoryCritical(JNIEnv *env, jobject thiz) {
+        texture_manager_memory_reset_memory_critical();
     }
 
     void Java_com_tealeaf_NativeShim_textureManagerSetMaxMemory(JNIEnv *env, jobject thiz, jint bytes) {

--- a/TeaLeaf/src/com/tealeaf/NativeShim.java
+++ b/TeaLeaf/src/com/tealeaf/NativeShim.java
@@ -511,6 +511,7 @@ public class NativeShim {
 	public native static void textureManagerSetMaxMemory(int bytes);
 	public native static void textureManagerMemoryWarning();
 	public native static void textureManagerMemoryCritical();
+	public native static void textureManagerMemoryReset();
 
 	//LocalStorage
 	public void setData(String key, String data) {

--- a/TeaLeaf/src/com/tealeaf/NativeShim.java
+++ b/TeaLeaf/src/com/tealeaf/NativeShim.java
@@ -511,7 +511,7 @@ public class NativeShim {
 	public native static void textureManagerSetMaxMemory(int bytes);
 	public native static void textureManagerMemoryWarning();
 	public native static void textureManagerMemoryCritical();
-	public native static void textureManagerMemoryReset();
+	public native static void textureManagerResetMemoryCritical();
 
 	//LocalStorage
 	public void setData(String key, String data) {

--- a/TeaLeaf/src/com/tealeaf/TeaLeaf.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeaf.java
@@ -46,6 +46,7 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
+import android.content.ComponentCallbacks2;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -77,6 +78,7 @@ import android.widget.AbsoluteLayout;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
+import android.app.ActivityManager;
 
 import org.json.JSONObject;
 
@@ -454,7 +456,16 @@ public class TeaLeaf extends FragmentActivity {
 			soundQueue.onResume();
 			soundQueue.playSound(SoundQueue.LOADING_SOUND);
 			PluginManager.callAll("onResume");
+
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+				final ActivityManager activityManager = (ActivityManager) instance.getSystemService(Context.ACTIVITY_SERVICE);
+				ActivityManager.RunningAppProcessInfo currentState = activityManager.getRunningAppProcesses().get(0);
+				ActivityManager.getMyMemoryState(currentState);
+				glView.onMemoryWarning(currentState.lastTrimLevel);
+			}
 		}
+
+
 	}
 
 	@Override
@@ -987,7 +998,11 @@ public class TeaLeaf extends FragmentActivity {
 	@Override
 	public void onLowMemory() {
 		if (glView != null) {
-			NativeShim.textureManagerMemoryCritical();
+			if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+				NativeShim.textureManagerMemoryCritical();
+			} else {
+				glView.onMemoryWarning(ComponentCallbacks2.TRIM_MEMORY_COMPLETE);
+			}
 		}
 	}
 

--- a/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
@@ -59,7 +59,7 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 	protected long glThreadId = 0;
 	public boolean queuePause = false;
 	private OrientationEventListener orientationListener;
-	private int lastTrimLevel = 0;
+	private int lastRunningTrimLevel = 0;
 
 	public TeaLeafOptions getOptions() {
 		return context.getOptions();
@@ -326,18 +326,18 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 	}
 
 	public void onMemoryWarning(int level) {
-		if (level > lastTrimLevel) {
+		if (level > lastRunningTrimLevel) {
 			if (level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
 				NativeShim.textureManagerMemoryCritical();
 			} else if (level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
 				NativeShim.textureManagerMemoryWarning();
 			}
-		} else if (level < lastTrimLevel) {
+		} else if (level < lastRunningTrimLevel) {
 			NativeShim.textureManagerResetMemoryCritical();
 		}
 
 		if (level <= ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
-			lastTrimLevel = level;
+			lastRunningTrimLevel = level;
 		}
 	}
 

--- a/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
@@ -59,6 +59,7 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 	protected long glThreadId = 0;
 	public boolean queuePause = false;
 	private OrientationEventListener orientationListener;
+	private int lastTrimLevel = 0;
 
 	public TeaLeafOptions getOptions() {
 		return context.getOptions();
@@ -325,11 +326,16 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 	}
 
 	public void onMemoryWarning(int level) {
-		if (level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
-			NativeShim.textureManagerMemoryCritical();
-		} else if (level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
-			NativeShim.textureManagerMemoryWarning();
+		if (level > lastTrimLevel) {
+			if (level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+				NativeShim.textureManagerMemoryCritical();
+			} else if (level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
+				NativeShim.textureManagerMemoryWarning();
+			}
+		} else if (level < lastTrimLevel) {
+			NativeShim.textureManagerMemoryReset();
 		}
+		lastTrimLevel = level;
 	}
 
 	@Override

--- a/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
@@ -333,7 +333,7 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 				NativeShim.textureManagerMemoryWarning();
 			}
 		} else if (level < lastTrimLevel) {
-			NativeShim.textureManagerMemoryReset();
+			NativeShim.textureManagerResetMemoryCritical();
 		}
 
 		if (level <= ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {

--- a/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
+++ b/TeaLeaf/src/com/tealeaf/TeaLeafGLSurfaceView.java
@@ -335,7 +335,10 @@ public class TeaLeafGLSurfaceView extends com.tealeaf.GLSurfaceView {
 		} else if (level < lastTrimLevel) {
 			NativeShim.textureManagerMemoryReset();
 		}
-		lastTrimLevel = level;
+
+		if (level <= ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+			lastTrimLevel = level;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
We don't need to send the same trim value to native, if onTrimMemory is
called multiple time by the OS. It will try to reduce memory limit every
time and max texture memory will reach a point where it won't be able to
hold all the texture we want to load in the screen.

Also, I found that when memory situation becomes better, OS is calling
onTrimMemory with lower values. We were handling it by half sizing,
which is wrong.