### PR TITLE
posix compliance

### DIFF
--- a/TeaLeaf/jni/js/js_native.cpp
+++ b/TeaLeaf/jni/js/js_native.cpp
@@ -15,6 +15,7 @@
  * along with the Game Closure SDK.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdlib.h>
+#include <sys/time.h>
 
 extern "C" {
 #include "core/config.h"

--- a/TeaLeaf/jni/lib/v8-profiler/node_buffer.cpp
+++ b/TeaLeaf/jni/lib/v8-profiler/node_buffer.cpp
@@ -33,6 +33,9 @@
 # include <arpa/inet.h> // htons, htonl
 #endif
 
+#ifdef MIN
+#undef MIN
+#endif
 
 #define MIN(a,b) ((a) < (b) ? (a) : (b))
 


### PR DESCRIPTION
Bionic was not written properly to comply to posix standards.
This fixes support for the Crystax NDK >= 10.3.0

https://www.crystax.net/en/blog/6

Tested and working with clang 3.7+ as the compiler and with libcrystax.so as the c library