### PR TITLE
uninstall should clear cache if clearstorage is passed

### DIFF
--- a/build.js
+++ b/build.js
@@ -942,7 +942,7 @@ function installAPK(api, config, apkPath, opts) {
 
   function tryUninstall(device) {
     var args = ['-s', device, 'shell', 'pm', 'uninstall'];
-    if (opts.clearstorage) {
+    if (!opts.clearstorage) {
       args.push('-k');
     }
     args.push(packageName);


### PR DESCRIPTION
The command was reversed.

If we want to keep original cache, then '-k' should be part of the argument list