### PR TITLE
prevent native android from breaking if theres a lot of dex strings

### DIFF
--- a/build.js
+++ b/build.js
@@ -443,7 +443,7 @@ function makeAndroidProject(api, app, config, opts) {
         ]);
     })
     .then(function () {
-      var dexDir = '\nout.dexed.absolute.dir=../.dex/\nsource.dir=src\n';
+      var dexDir = '\nout.dexed.absolute.dir=../.dex/\nsource.dir=src\ndex.force.jumbo=true\n';
       return [
         fs.appendFileAsync(projectPropertiesFile, dexDir),
         saveLocalizedStringsXmls(opts.outputPath, config.titles),


### PR DESCRIPTION
We had a lot of dex strings being formed for mahjong whih was breaking build

http://stackoverflow.com/questions/26093664/android-studio-only-dexexception-cannot-merge-new-index-65536-into-a-non-jumbo

4th optioon here ^